### PR TITLE
Add Banner click track event w/ necessary util for variant text

### DIFF
--- a/content/source/assets/javascripts/analytics.js
+++ b/content/source/assets/javascripts/analytics.js
@@ -13,4 +13,15 @@ document.addEventListener('turbolinks:load', function() {
       product: 'terraform'
     }
   })
+
+  track('a.notification', function(el) {
+    var params = {
+      name: 'Alert Banner',
+      variant: el.innerText.replace(/\s+/g, ' ').trim()
+    }
+    // Create a stringified `label` prop of the event for GA tracking purposes
+    params.label = JSON.stringify(params)
+    params.event = 'CTA Clicked'
+    return params
+  })
 })


### PR DESCRIPTION
[**Asana Task**](https://app.asana.com/0/346384260719996/1130685477827055/f)

- Adds **'CTA Clicked'** track event to 'Alert Banner' for usage with GA + Google Optimize

- See Asana task for screenshot of the element we're binding this event to. e.g. `a.notification`

- Based on the thread on Asana, we want to only pass in the text content for tracking the `variant` prop -- this PR includes a small util to strip HTML and return only text content in that prop

- Here's what it looks like in the Segment debugger:
![Screenshot 2019-07-15 12 00 01](https://user-images.githubusercontent.com/7191639/61234201-17a06a80-a6f8-11e9-822e-075dc9d50f05.png)
![Screenshot 2019-07-15 11 59 52](https://user-images.githubusercontent.com/7191639/61234208-1a9b5b00-a6f8-11e9-9b36-074c57d428af.png)


The event obj looks as follows:

```javascript
analytics.track('CTA Clicked', {
  label: '{"name":"Alert Banner","variant":"New Introducing Terraform Cloud Remote State Management Sign Up For Free"}',
  name: 'Alert Banner',
  variant: 'New Introducing Terraform Cloud Remote State Management Sign Up For Free'
});
```

